### PR TITLE
feat: add support for custom 404 page

### DIFF
--- a/docs/pages/01-basics.md
+++ b/docs/pages/01-basics.md
@@ -35,6 +35,7 @@ Yeah... and no.
 - `_head.html` - will add the header section to the final HTML (deprecated in v0.2.7)
 - `_tail.html` - will add the footer section to the final HTML (deprecated in v0.2.7)
 - `_layout.html` - defines a common layout for all files that'll be rendered.
+- `_404.html` - alvu will serve this file whenever the requested page is not found. (Nested within `_layout.html`, if exists)
 
 The `_head.html` and `_tail.html` files were used as placeholders for
 repeated layout across your markdown files, this has now been replaced

--- a/docs/pages/404.html
+++ b/docs/pages/404.html
@@ -1,0 +1,7 @@
+<div>
+  <h1>404</h1>
+  <p>You seem lost...</p>
+  <p>
+    <a href="{{.Meta.BaseURL}}"> &larr; Go Back? </a>
+  </p>
+</div>

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -66,8 +65,6 @@ var notFoundPageExists bool
 var release string
 
 var layoutFiles []string = []string{"_head.html", "_tail.html", "_layout.html"}
-
-// var reservedFiles []string = []string{"_404.html"} // no special attention required as of now
 
 type SiteMeta struct {
 	BaseURL string
@@ -177,7 +174,7 @@ func main() {
 	headFilePath := path.Join(pagesPath, "_head.html")
 	baseFilePath := path.Join(pagesPath, "_layout.html")
 	tailFilePath := path.Join(pagesPath, "_tail.html")
-	notFoundFilePath := path.Join(pagesPath, "_404.html")
+	notFoundFilePath := path.Join(pagesPath, "404.html")
 	outPath = path.Join(*outPathFlag)
 	hooksPath := path.Join(*basePathFlag, *hooksPathFlag)
 	hardWraps = *hardWrapsFlag
@@ -893,7 +890,8 @@ func normalizeFilePath(path string) string {
 
 func notFoundHandler(w http.ResponseWriter, r *http.Request) {
 	if notFoundPageExists {
-		notFoundFile, err := ioutil.ReadFile(filepath.Join(outPath, "_404.html"))
+		compiledNotFoundFile := filepath.Join(outPath, "404.html")
+		notFoundFile, err := os.ReadFile(compiledNotFoundFile)
 		if err != nil {
 			http.Error(w, "404, Page not found....", http.StatusNotFound)
 			return

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 
 	"io"
 	"io/fs"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -59,11 +60,14 @@ var hardWraps bool
 var hookCollection HookCollection
 var reloadCh = []chan bool{}
 var serveFlag *bool
+var notFoundPageExists bool
 
 //go:embed .commitlog.release
 var release string
 
-var reservedFiles []string = []string{"_head.html", "_tail.html", "_layout.html"}
+var layoutFiles []string = []string{"_head.html", "_tail.html", "_layout.html"}
+
+// var reservedFiles []string = []string{"_404.html"} // no special attention required as of now
 
 type SiteMeta struct {
 	BaseURL string
@@ -173,6 +177,7 @@ func main() {
 	headFilePath := path.Join(pagesPath, "_head.html")
 	baseFilePath := path.Join(pagesPath, "_layout.html")
 	tailFilePath := path.Join(pagesPath, "_tail.html")
+	notFoundFilePath := path.Join(pagesPath, "_404.html")
 	outPath = path.Join(*outPathFlag)
 	hooksPath := path.Join(*basePathFlag, *hooksPathFlag)
 	hardWraps = *hardWrapsFlag
@@ -228,6 +233,17 @@ func main() {
 		}
 	} else {
 		fmt.Println(headTailDeprecationWarning.String())
+	}
+
+	onDebug(func() {
+		debugInfo("Checking if _404.html exists")
+		memuse()
+	})
+	if _, err := os.Stat(notFoundFilePath); errors.Is(err, os.ErrNotExist) {
+		notFoundPageExists = false
+		log.Println("no _404.html found, skipping")
+	} else {
+		notFoundPageExists = true
 	}
 
 	alvuApp.CopyPublic()
@@ -337,7 +353,7 @@ func CollectFilesToProcess(basepath string) []string {
 	for _, pathInfo := range pathstoprocess {
 		_path := path.Join(basepath, pathInfo.Name())
 
-		if Contains(reservedFiles, pathInfo.Name()) {
+		if Contains(layoutFiles, pathInfo.Name()) {
 			continue
 		}
 
@@ -876,8 +892,18 @@ func normalizeFilePath(path string) string {
 }
 
 func notFoundHandler(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNotFound)
-	fmt.Fprint(w, "404, Page not found....")
+	if notFoundPageExists {
+		notFoundFile, err := ioutil.ReadFile(filepath.Join(outPath, "_404.html"))
+		if err != nil {
+			http.Error(w, "404, Page not found....", http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write(notFoundFile)
+		return
+	}
+	http.Error(w, "404, Page not found....", http.StatusNotFound)
 }
 
 func Contains(collection []string, item string) bool {


### PR DESCRIPTION
- Adds support for custom 404 (Not Found) page.
- Allows users to create `/pages/_404.html` to serve as standard Not Found Page.
- Update docs.