### PR TITLE
fix: handle malformed frontmatter in ParseMeta function

### DIFF
--- a/main.go
+++ b/main.go
@@ -512,6 +512,9 @@ func (af *AlvuFile) ParseMeta() error {
 	}
 
 	metaParts := bytes.SplitN(af.content, sep, 3)
+	if len(metaParts) < 3 {
+		return fmt.Errorf("malformed frontmatter: expected YAML block between '---' markers")
+	}
 
 	var meta map[string]interface{}
 	err := yaml.Unmarshal([]byte(metaParts[1]), &meta)


### PR DESCRIPTION
Added a check to ensure that the frontmatter contains the expected YAML block between '---' markers, returning an error if the format is incorrect.