### PR TITLE
fix: improve file handling in copyDir function

### DIFF
--- a/main.go
+++ b/main.go
@@ -1074,15 +1074,18 @@ func copyDir(src string, dest string) error {
 				return err
 			}
 		} else {
-			dest, err := os.OpenFile(filepath.Join(dest, s.Name()), os.O_CREATE|os.O_WRONLY, os.ModePerm)
+			destFile, err := os.OpenFile(filepath.Join(dest, s.Name()), os.O_CREATE|os.O_WRONLY, os.ModePerm)
 			if err != nil {
 				return err
 			}
-			src, err := os.OpenFile(filepath.Join(src, s.Name()), os.O_RDONLY, os.ModePerm)
+			srcFile, err := os.OpenFile(filepath.Join(src, s.Name()), os.O_RDONLY, os.ModePerm)
 			if err != nil {
+				destFile.Close()
 				return err
 			}
-			_, err = io.Copy(dest, src)
+			_, err = io.Copy(destFile, srcFile)
+			srcFile.Close()
+			destFile.Close()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Refactor the copyDir function to use more descriptive variable names for destination and source file handles, ensuring proper closure of file handles to prevent resource leaks.